### PR TITLE
Fixed NPC spawns by removing navmesh from NPC struct

### DIFF
--- a/agent-server/handler/inventory/inventory_handler.go
+++ b/agent-server/handler/inventory/inventory_handler.go
@@ -102,7 +102,7 @@ func moveItem(data server.PacketChannelData) {
 
 	world := service.GetWorldServiceInstance()
 	player, err := world.GetPlayerByCharName(data.Session.UserContext.CharName)
-	if err == nil {
+	if err != nil {
 		// player not online
 		logrus.Tracef("Player %s is not online\n", player.CharName)
 		return

--- a/agent-server/model/npc.go
+++ b/agent-server/model/npc.go
@@ -1,14 +1,12 @@
 package model
 
 import (
-	"github.com/ferdoran/go-sro/agent-server/navmeshv2"
 	"github.com/sirupsen/logrus"
 	"sync"
 )
 
 type NPC struct {
 	SRObject
-	navmeshv2.RtNavmeshPosition
 	Type         string
 	Mutex        *sync.Mutex
 	UniqueID     uint32


### PR DESCRIPTION
Hello ferdoran!

Big fan of what you did here, thanks for developing this in public! 
When tested what you already implemented, i found that no NPC spawned for me. This is what my game looked like when i first connected to the server:

https://github.com/user-attachments/assets/527f3dd5-2f58-4668-b53f-4212e5cf61c0

I played around with your code and found that the `NavmeshPosition` of the NPC's are correctly calculated by the `generateRandomPositionInRadius` function. However, when using the function `GetNavmeshPosition` afterwards, I got a `RtNavmeshPosition` back with all attributes set to 0 (e.g. Region.ID, Region.X).

I then saw that your `NPC` struct, **aswell as** the `SRObject` struct contain a `RtNavmeshPosition`. When I removed it from the NPC struct, everything seems to work as you inteded it to:

https://github.com/user-attachments/assets/d14a0576-9baf-47c8-ba75-e24be691b024

I am new to Go (and contributing on github) so I am not familiar with embedding of structs yet. But my guess is that having the `RtNavmeshPosition` in both structs causes the issue. 

I hope this might be useful to you.

Cheers and thanks again for making this repo public!